### PR TITLE
fix duplicate device names

### DIFF
--- a/bin/matrix-sim.js
+++ b/bin/matrix-sim.js
@@ -60,6 +60,7 @@ if ( cmd === 'init' ) {
       deviceId: deviceId,
       deviceName: inputs.name,
       deviceDescription: inputs.description,
+      user: Matrix.config.user.id,
     };
 
     Matrix.api.device.create(deviceObj, function ( err, device ) {


### PR DESCRIPTION
Include the user id for validation on the API of devices with the same name 