### PR TITLE
Remove the false error when creating a device

### DIFF
--- a/bin/matrix-register.js
+++ b/bin/matrix-register.js
@@ -58,7 +58,6 @@ Matrix.localization.init(Matrix.localesFolder, Matrix.config.locale, function ()
                 error: function (err) {
                   if (err.hasOwnProperty('state') && err.state == 'device-provisioning-in-progress') {
                     debug('Provisioning device step... ignore this')
-                    //Provisioning step, ignore this
                   } else {
                     console.log('Error creating device '.red + deviceObj.name.yellow + ': '.red, err);
                     process.exit();

--- a/bin/matrix-register.js
+++ b/bin/matrix-register.js
@@ -14,7 +14,6 @@ Matrix.localization.init(Matrix.localesFolder, Matrix.config.locale, function ()
       Matrix.validate.user(); //Make sure the user has logged in
       console.log(t('matrix.register.creating_device'))
 
-
       // do device Registration
       var deviceSchema = {
         properties: {
@@ -57,8 +56,13 @@ Matrix.localization.init(Matrix.localesFolder, Matrix.config.locale, function ()
 
               var events = {
                 error: function (err) {
-                  console.log('Error creating device '.red + deviceObj.name.yellow + ': '.red, err);
-                  // process.exit();
+                  if (err.hasOwnProperty('state') && err.state == 'device-provisioning-in-progress') {
+                    debug('Provisioning device step... ignore this')
+                    //Provisioning step, ignore this
+                  } else {
+                    console.log('Error creating device '.red + deviceObj.name.yellow + ': '.red, err);
+                    process.exit();
+                  }
                 },
                 finished: function () {
                   console.log('Device registered succesfully');


### PR DESCRIPTION
This is done to ignore the device provisioning state, this is not an error, just an additional step at the end of the worker task life

**_Requires matrix-firebase update_**