### PR TITLE
Specify content type for uploads

### DIFF
--- a/bin/matrix-deploy.js
+++ b/bin/matrix-deploy.js
@@ -127,7 +127,7 @@ Matrix.localization.init(Matrix.localesFolder, Matrix.config.locale, function ()
     var downloadFileName = Matrix.config.user.id + '.zip';
     details.file = fileUrl + '/' + appName + '/' + downloadFileName;
     Matrix.firebaseInit(function (err) {
-      Matrix.helpers.getUploadUrl(downloadFileName, appName, function (err, uploadUrl) {
+      Matrix.helpers.getUploadUrl(downloadFileName, appName, 'zip', function (err, uploadUrl) {
         if (!err) {
           Matrix.helpers.uploadPackage(destinationFilePath, uploadUrl, function (err) {
             var appData = {

--- a/bin/matrix-publish.js
+++ b/bin/matrix-publish.js
@@ -138,7 +138,7 @@ Matrix.localization.init(Matrix.localesFolder, Matrix.config.locale, function ()
       async.parallel([
         function (next) {
           if (hasReadme) {
-            Matrix.helpers.getUploadUrl(remoteReadmeFileName, appName, function (err, readmeUploadUrl) {
+            Matrix.helpers.getUploadUrl(remoteReadmeFileName, appName, 'text', function (err, readmeUploadUrl) {
               if (err) {
                 next(err);
               } else {
@@ -152,7 +152,7 @@ Matrix.localization.init(Matrix.localesFolder, Matrix.config.locale, function ()
           }
         }
         , function (next) {
-          Matrix.helpers.getUploadUrl(downloadFileName, appName, function (err, uploadUrl) {
+          Matrix.helpers.getUploadUrl(downloadFileName, appName, 'zip', function (err, uploadUrl) {
             if (!err) {
               Matrix.helpers.uploadPackage(destinationFilePath, uploadUrl, function (err) {
                 next(err);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -678,12 +678,21 @@ function checkAppCode(path, cb) {
   }
 }
 
-function getUploadUrl(fileName, appName, cb) {
+/**
+ * @description Retrieve the resumable upload url from the API 
+ * @param fileName Filename to use for the download (Sent as version to the API)
+ * @param appName Upload URL
+ * @param type Specify the Content-Type that will be set (zip, text)
+ * @param cb Callback
+ */
+function getUploadUrl(fileName, appName, type, cb) {
+  
   debug("Retreiving upload url");
   var url = Matrix.config.environment.api + '/' + uploadEndpoint
     + '?access_token=' + Matrix.config.user.token
     + '&appName=' + appName
-    + '&version=' + fileName;
+    + '&version=' + fileName
+    + '&type=' + type;
 
   debug('get', url);
   request.get(url, function (error, response, body) { //Get the upload URL


### PR DESCRIPTION
This adds a `type` param to the GET request that generates a resumable upload on the API (**v2/app/resources/uploadurl**). This resumable upload URL is used to upload the readme file and the app package file.