### PR TITLE
fix user validate

### DIFF
--- a/bin/matrix-validate.js
+++ b/bin/matrix-validate.js
@@ -1,10 +1,12 @@
 //Check if a user is logged in
 function user() {
-  token();
+
   if (_.isEmpty(Matrix.config.user)) {
     Matrix.loader.stop();
     console.error(t('matrix.please_login').yellow);
     process.exit();
+  }else{
+    token();
   }
 }
 


### PR DESCRIPTION
If `Matrix.config.user` is empty the method token show this error:

```
TypeError: Cannot read property 'token' of undefined
    at token (/usr/lib/node_modules/matrix-cli/bin/matrix-validate.js:23:33)
    at Object.user (/usr/lib/node_modules/matrix-cli/bin/matrix-validate.js:3:3)
    at /usr/lib/node_modules/matrix-cli/bin/matrix-register.js:14:23
    at /usr/lib/node_modules/matrix-cli/node_modules/node-yaml-localize/lib/node-yaml-localize/translator.js:175:24
    at next (/usr/lib/node_modules/matrix-cli/node_modules/node-yaml-localize/lib/node-yaml-localize/translator.js:228:35)
    at /usr/lib/node_modules/matrix-cli/node_modules/node-yaml-localize/lib/node-yaml-localize/translator.js:240:25
    at FSReqWrap.oncomplete (fs.js:123:15)
```
 On that PR verity if the `Matrix.config.user` is different of undefined for call the method.