### PR TITLE
If app fails starting (error) notify instead of waiting for timeout

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -156,12 +156,17 @@ async.series([
               //Watch the app status and verify if the behavior it's right
               Matrix.firebase.app.watchStatus(appId, function (status) {
                 //stop command status behavior(inactive or error -> active)
-                Matrix.loader.stop()
                 if(status === 'active'){
                   clearTimeout(commandTimeout);
+                  Matrix.loader.stop();
                   console.log(t('matrix.start.start_app_successfully') + ': ', app);
                   endIt();
-                }
+                } else if (status === 'error') {
+                  clearTimeout(commandTimeout);
+                  Matrix.loader.stop();
+                  console.error('The application failed to start, please update it and try again. \nIf it keeps failing you may want to contact the developer.'.yellow);
+                  endIt();
+                }  
 
               });
               //Send the start command


### PR DESCRIPTION
If the app status changes from inactive to error, notify and stop instead of waiting for the timeout