### PR TITLE
Adjust the way images are sent to the worker on app deployment and publication

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -90,28 +90,28 @@ function checkConfigWrite() {
 function copyFile(source, target, cb) {
   var cbCalled = false;
 
-  var rd = fs.createReadStream(source);
-  rd.on("error", function(err) {
-    done(err);
-  });
-
-  var wr = fs.createWriteStream(target);
-  wr.on("error", function(err) {
-    done(err);
-  });
-
-  wr.on("close", function(ex) {
-    done();
-  });
-
-  rd.pipe(wr);
-
   function done(err) {
     if (!cbCalled) {
       cb(err);
       cbCalled = true;
     }
-  }
+  }  
+
+  var rd = fs.createReadStream(source);
+  rd.on('error', function(err) {
+    done(err);
+  });
+
+  var wr = fs.createWriteStream(target);
+  wr.on('error', function(err) {
+    done(err);
+  });
+
+  wr.on('close', function(ex) {
+    done();
+  });
+
+  rd.pipe(wr); 
 }
 
 function updateFile(content, path, cb) {
@@ -454,9 +454,6 @@ function displayDeviceApps(deviceapps) {
   }
 }
 
-function packageApp(name) {
-  // zip up folder
-}
 
 function cleanPolicy(policy) {
   _.each(policy, function(value, key) {
@@ -901,7 +898,7 @@ function getUploadUrl(fileName, appName, type, cb) {
     }
     return cb(error, resultUrl);
   });
-};
+}
 
 /**
  * @description Method used with GCS resumable uploads
@@ -927,7 +924,7 @@ function uploadPackage(path, uploadUrl, cb) {
   stream.on('error', function(err) {
     return cb(new Error('Error reading file (' + path + '): \n', err));
   });
-};
+}
 
 /**
  * Makes sure the config param is an array, otherwise returns an appropriate array. Defaults to ['Development']
@@ -960,12 +957,7 @@ function formParamArray(configObject, param) {
 
 //Gets the config, policy and forms app object
 function collectAppData(name, path, cb) {
-  debug("Collecting app data...");
-
-  var configFile = fs.readFileSync(path + appDetectFile).toString();
-  if (configFile.hasOwnProperty('icon')) {
-    //TODO Upload icon?
-  }
+  debug('Collecting app data...');
 
   var config;
   try {
@@ -1011,6 +1003,46 @@ function collectAppData(name, path, cb) {
     return cb(err);
   }
 }
+
+/**
+ * @description Forms the structure required to submit an app (deploy and publish)
+ * @param {JSON} appDetails
+ * @returns {JSON} JSON with properly named keys for Firebase submission
+ */
+function formAppData(appDetails){
+  
+  var result = {};
+  result.meta = _.pick(appDetails, ['name', 'description', 'shortname', 'keywords', 'categories', 'version', 'file']);
+  result.file = appDetails.file; //TODO Remove this once it isn't required
+  result.version = appDetails.version; //TODO Remove this once it isn't required
+
+  if (_.has(appDetails.config, 'galleryUrl') || _.has(appDetails.config, 'imageUrls')) {
+    result.assets = {}; //TODO Remove this once the appstore and workers stop using it
+    result.meta.assets = {};
+  }
+  
+  if (_.has(appDetails.config, 'galleryUrl')) { //If it has a gallery image
+    result.assets.icon = appDetails.config.galleryUrl; //TODO Remove this once the appstore and workers stop using it
+    result.meta.assets.icon = appDetails.config.galleryUrl;
+  }
+  
+  if (_.has(appDetails.config, 'imageUrls') && _.isArray(appDetails.config.imageUrls) && appDetails.config.imageUrls.length > 0) { 
+    if (!_.has(appDetails.config, 'galleryUrl')) { //If it doesn't have a gallery image
+      result.assets.icon = appDetails.config.imageUrls[0]; //TODO Remove this once the appstore and workers stop using it
+      result.meta.assets.icon = appDetails.config.imageUrls[0]; 
+    }
+    result.meta.assets.images = appDetails.config.imageUrls;
+  }
+  
+  result.config = appDetails.config;
+  result.policy = appDetails.policy;
+
+  debug('DOWNLOAD URL: ' + result.file);
+  debug('The data sent for ' + result.meta.name + ' ( ' + result.version + ' ) is: ', result);
+
+  return result;
+}
+
 
 /**
  * @description Creates a zip file with the contents of an app folder
@@ -1201,6 +1233,7 @@ module.exports = {
   displayGroups: displayGroups,
   displayKeyValue: displayKeyValue,
   displaySearch: displaySearch,
+  formAppData: formAppData,
   getConfig: getConfig,
   getUploadUrl: getUploadUrl,
   installApp: installApp,
@@ -1208,7 +1241,6 @@ module.exports = {
   logout: logout,
   lookupAppId: lookupAppId,
   lookupDeviceName: lookupDeviceName,
-  packageApp: packageApp,
   patchVersion: patchVersion,
   profile: profile,
   removeConfig: removeConfig,


### PR DESCRIPTION
- Unify deploy and publish app structure formation (Uses helpers)
- Unused vars clean up on deploy and publish
- Read galleryUrl from config yaml for the app icon
- Read imageUrls from config yaml for the app images
- Use first imageUrls if no galleryUrl is provided