### PR TITLE
Improved app start/stop/restart message and exit

### DIFF
--- a/bin/matrix-list.js
+++ b/bin/matrix-list.js
@@ -17,9 +17,12 @@ Matrix.localization.init(Matrix.localesFolder, Matrix.config.locale, function ()
 
     if (target.match(/all/)) {
       Matrix.firebase.user.getAllApps(function (err, resp) {
-        if (_.isEmpty(resp)) return console.error(t('matrix.list.no_results'));
-        debug('Device List>', resp);
         Matrix.loader.stop();
+        if (_.isEmpty(resp)) {
+          console.error(t('matrix.list.no_results'));
+          process.exit(1);
+        }
+        debug('Device List>', resp);
         console.log(Matrix.helpers.displayDeviceApps(resp));
 
         // save for later
@@ -32,7 +35,10 @@ Matrix.localization.init(Matrix.localesFolder, Matrix.config.locale, function ()
       Matrix.validate.device(); //Make sure the user has selected a device
       Matrix.firebase.app.list(function (err, apps) {
         Matrix.loader.stop();
-        if (err) return console.error('- ', t('matrix.list.app_list_error') + ':', err);
+        if (err) {
+          console.error('- ', t('matrix.list.app_list_error') + ':', err);
+          process.exit(1);
+        }
         if (_.isUndefined(apps) || _.isNull(apps)) apps = {};
 
         //Retrieve status for each app
@@ -84,7 +90,10 @@ Matrix.localization.init(Matrix.localesFolder, Matrix.config.locale, function ()
             }
           })
         }, function (err) {
-          if (err) return console.error(err.red);
+          if (err) {
+            console.error(err.red);
+            process.exit(1);
+          }
           console.log(Matrix.helpers.displayDevices(deviceMap));
           Matrix.config.deviceMap = deviceMap;
           Matrix.helpers.saveConfig(function () {

--- a/lib/app.js
+++ b/lib/app.js
@@ -117,13 +117,17 @@ async.series([
     .description(t('matrix.help_start'))
     .option('-a, --all')
     .action(function startMatrixApp(app, options) {
-      //Make sure the user has logged in
-      Matrix.validate.user();
-      Matrix.validate.device();
-
+      
+      Matrix.validate.user(); //Make sure the user has logged in
+      Matrix.validate.device(); //And it has selected a device
       Matrix.helpers.trackEvent('app-start', { aid: app, did: Matrix.config.device.identifier });
-
       Matrix.api.device.setId(Matrix.config.device.identifier);
+
+      if (_.isUndefined(app) || !_.isString(value)) {
+        console.log('\n> matrix start <app> - ' + t('matrix.help_start').grey + '\n'); 
+        process.exit(1);
+      }
+
       console.log(t('matrix.start.starting_app') + ': ', app, Matrix.config.device.identifier);
 
       Matrix.firebaseInit(function () {
@@ -203,8 +207,12 @@ async.series([
       //Make sure the user has logged in
       Matrix.validate.user();
       Matrix.validate.device();
-
       Matrix.helpers.trackEvent('app-stop', { aid: app, did: Matrix.config.device.identifier });
+
+      if (_.isUndefined(app) || !_.isString(value)) {
+        console.log('\n> matrix stop <app> - ' + t('matrix.help_stop').grey + '\n'); 
+        process.exit(1);
+      }
 
       Matrix.firebaseInit(function () {
         //Get the app id for name
@@ -275,8 +283,12 @@ async.series([
       //Make sure the user has logged in
       Matrix.validate.user();
       Matrix.validate.device();
-
       Matrix.helpers.trackEvent('app-restart', { aid: app, did: Matrix.config.device.identifier });
+
+      if (_.isUndefined(app) || !_.isString(value)) {
+        console.log('\n> matrix restart <app> - ' + t('matrix.help_restart').grey + '\n'); 
+        process.exit(1);
+      }
 
       Matrix.firebaseInit(function () {
         //Get the app id for name

--- a/lib/app.js
+++ b/lib/app.js
@@ -123,7 +123,7 @@ async.series([
       Matrix.helpers.trackEvent('app-start', { aid: app, did: Matrix.config.device.identifier });
       Matrix.api.device.setId(Matrix.config.device.identifier);
 
-      if (_.isUndefined(app) || !_.isString(value)) {
+      if (_.isUndefined(app) || !_.isString(app)) {
         console.log('\n> matrix start <app> - ' + t('matrix.help_start').grey + '\n'); 
         process.exit(1);
       }
@@ -209,7 +209,7 @@ async.series([
       Matrix.validate.device();
       Matrix.helpers.trackEvent('app-stop', { aid: app, did: Matrix.config.device.identifier });
 
-      if (_.isUndefined(app) || !_.isString(value)) {
+      if (_.isUndefined(app) || !_.isString(app)) {
         console.log('\n> matrix stop <app> - ' + t('matrix.help_stop').grey + '\n'); 
         process.exit(1);
       }
@@ -285,7 +285,7 @@ async.series([
       Matrix.validate.device();
       Matrix.helpers.trackEvent('app-restart', { aid: app, did: Matrix.config.device.identifier });
 
-      if (_.isUndefined(app) || !_.isString(value)) {
+      if (_.isUndefined(app) || !_.isString(app)) {
         console.log('\n> matrix restart <app> - ' + t('matrix.help_restart').grey + '\n'); 
         process.exit(1);
       }

--- a/lib/app.js
+++ b/lib/app.js
@@ -129,7 +129,10 @@ async.series([
       Matrix.firebaseInit(function () {
         //Get the app id for name
         Matrix.firebase.app.getIDForName( app, function(err, appId){
-          if (err) return console.error(err);
+          if (err) {
+            console.error(err.message); 
+            process.exit(1);
+          }
           debug('appId>', appId);
           //Get the current status of app
           Matrix.firebase.app.getStatus(appId, function (status) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -209,7 +209,10 @@ async.series([
       Matrix.firebaseInit(function () {
         //Get the app id for name
         Matrix.firebase.app.getIDForName( app, function(err, appId){
-          if (err) return console.error(err);
+          if (err) {
+            console.error(err.message);
+            return process.exit(1);
+          }
           debug('appId>', appId);
           //Get the current status of app
           Matrix.firebase.app.getStatus(appId, function (status) {
@@ -278,7 +281,10 @@ async.series([
       Matrix.firebaseInit(function () {
         //Get the app id for name
         Matrix.firebase.app.getIDForName( app, function(err, appId){
-          if (err) return console.error(err);
+          if (err) {
+            console.error(err);
+            return process.exit(1);
+          }
           debug('appId>', appId);
           //Get the current status of app
           Matrix.firebase.app.getStatus(appId, function (status) {


### PR DESCRIPTION
Removed stack trace from warning message when an app name doesn't exist on matrix start/stop/restart, also, on that case it is now exiting without further input required