### PR TITLE
Ping command does'nt throw TypeError

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -160,8 +160,10 @@ async.series([
           Matrix.validate.deviceAsync,
           async.apply(Matrix.api.app.trigger, Matrix.config.device.identifier, 'amazing-matrix-ping')
         ], function (err) {
-          console.error(err.message.red);
-          debug('Error:', err);
+          if (err) {
+            console.error(err.message.red);
+            debug('Error:', err);
+          }          
           return endIt();
         });
 


### PR DESCRIPTION
Ping command was throwing TypeError when matrix ping  was blank so i move console error to conditional err at command('ping') as appointed at one issue