### PR TITLE
Helper error function added to print error logs

### DIFF
--- a/bin/matrix-init.js
+++ b/bin/matrix-init.js
@@ -22,6 +22,7 @@ t = Matrix.localization.get; // international translator
 
 
 Matrix.helpers = require('../lib/helpers');
+Matrix.error = Matrix.helpers.error;
 //sets Matrix.config with local variables
 Matrix.config = _.assign(Matrix.config, Matrix.helpers.getConfig());
 //set default locale

--- a/lib/app.js
+++ b/lib/app.js
@@ -162,7 +162,7 @@ async.series([
           async.apply(Matrix.api.app.trigger, Matrix.config.device.identifier, 'amazing-matrix-ping')
         ], function (err) {
           if (err) {
-            console.error(err.message.red);
+            Matrix.error(err); //Print error
             debug('Error:', err);
           }          
           return endIt();

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,6 +14,23 @@ const installTimeoutSeconds = 30; //seconds to get a install response from devic
 
 var configFile = require('os').homedir() + '/.matrix/store.json';
 
+/**
+ * Prints a friendly error message to the terminal including source if provided
+ * @param {Error|String} err Error object or Error message string to print
+ * @param {String} source Source of the error, this will be included before the error in the following format (<source>)
+ */
+function error(err, source) { 
+  if (err) {
+    var errorMessage = err.message ? err.message : err; //Fetch message
+    if (typeof errorMessage === 'string') errorMessage = errorMessage.red; //Paint it red
+    else if (!(err instanceof Error)) errorMessage = JSON.stringify(errorMessage); //This is a little hackish, could be removed if undesired
+    if (source && typeof source === 'string') errorMessage = '(' + source.yellow + ') ' + errorMessage; //Add (source): <err>
+    console.error(errorMessage); //Actually print the error message
+  } else { 
+    debug('Unable to print error'.yellow, err);  
+  }
+}
+
 function trackEvent(eventName, extras, cb) {
 
   debug('Track Event'.yellow, eventName, extras);
@@ -1407,6 +1424,7 @@ module.exports = {
   displayGroups: displayGroups,
   displayKeyValue: displayKeyValue,
   displaySearch: displaySearch,
+  error: error,
   formAppData: formAppData,
   getConfig: getConfig,
   getUploadUrl: getUploadUrl,


### PR DESCRIPTION
**matrix ping** error log fixed (not printing error possibly due to lack of validation)

**Matrix.error** receives 2 parameters 
- **err**: Error object or error message
- **source**: Optional source string that is printed before the message surrounded by ()


**The following code:**
![screen shot 2018-04-27 at 11 32 24 am](https://user-images.githubusercontent.com/11444484/39388114-437834e8-4a43-11e8-8a8c-4bcfde87a975.png)

**Has the following output:**
![screen shot 2018-04-27 at 11 32 33 am](https://user-images.githubusercontent.com/11444484/39388117-488b7170-4a43-11e8-8074-581b842e80b1.png)

