### PR TITLE
Update device List table

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,7 +305,7 @@ en:
       devices:
         device_id: Device ID
         name: Name
-        ok: ok
+        status: Online
         description: Description
         last_online: Last Online
       groups:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -265,7 +265,7 @@ es:
       devices:
         device_id: ID de dispositivo
         name: Nombre
-        ok: ok
+        status: Estado
         description: Descripción
         last_online: Última sesión
       groups:

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -309,7 +309,7 @@ function displayApps(apps) {
   });
 
   try {
-    debug('apps list'.red);
+    console.log('Listing Apps:'.red);
     JSON.stringify(table);
   } catch (err) {
     console.log('err', err)
@@ -339,25 +339,28 @@ function displayDevices(devices) {
   var table = new Table({
     chars: { 'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': '' },
     head: [t('matrix.helpers.devices.device_id').underline, t('matrix.helpers.devices.name').underline,
-    t('matrix.helpers.devices.description').underline, t('matrix.helpers.devices.ok').underline, t('matrix.helpers.devices.last_online').underline
-    ],
-    colWidths: [20, 20, 25 + ttyExtra, 4, 15]
+    t('matrix.helpers.devices.description').underline, t('matrix.helpers.devices.status').underline, t('matrix.helpers.devices.last_online').underline],
+    colWidths: [20, 20, 21 + ttyExtra, 8, 15]
   });
 
   //transform
 
-
   _.forEach(devices, function (device, deviceId) {
 
     var currentDevice = Matrix.validate.isCurrentDevice(deviceId);
-
+    
+    var lastSeen;
+    if (!device.lastSeen || device.lastSeen === 0) lastSeen = '-'; //No trace of it
+    else if (device.online) lastSeen = 'Now'; //It is online now
+    else lastSeen = moment.unix(device.lastSeen, "YYYYMMDD").fromNow(); //Last time seen
+    
     //Set values
     var deviceToShow = {
       id: deviceId,
       name: device.name || '',
       description: device.description || '',
-      status: device.online ? 'ok' : 'no',
-      time: device.lastSeentime === 0 ? '-' : moment.unix(device.lastSeen, "YYYYMMDD").fromNow()
+      status: '•',
+      time: lastSeen
     };
 
     //Color
@@ -371,12 +374,12 @@ function displayDevices(devices) {
       deviceToShow.status = device.online ? deviceToShow.status.green : deviceToShow.status.red;
     }
 
-    table.push([deviceToShow.id, deviceToShow.name, deviceToShow.description, deviceToShow.status, deviceToShow.time]);
+    table.push([deviceToShow.id, deviceToShow.name, deviceToShow.description, { hAlign: 'center', content: deviceToShow.status }, { hAlign: 'center', content: deviceToShow.time }]);
 
   });
 
   try {
-    console.log('devices list'.red);
+    console.log('Listing Devices:'.red);
     JSON.stringify(table);
   } catch (err) {
     console.log('err', err)
@@ -400,7 +403,7 @@ function displayGroups(groups) {
   });
 
   try {
-    debug('groups list'.red);
+    console.log('Listing Groups:'.red);
     JSON.stringify(table);
   } catch (err) {
     console.log('err', err)
@@ -441,7 +444,7 @@ function displaySearch(raw, needle) {
   })
 
   try {
-    console.log('Search results'.red);
+    console.log('Search results:'.red);
     return JSON.stringify(table);
   } catch (err) {
     console.log('err', err)


### PR DESCRIPTION
- For devices that haven't ever been online, show `-` instead of `48 years ago` as the **Last Seen** value.
- For devices that are currently only show `Now` under **Last Seen**
- Change **ok** header to **Status**
- Center **Last Seen** and **Status** content
- For **Status** content use a colored `•` instead of `ok` and `no`
- Update logs before listing for consistency